### PR TITLE
Add AGPL license notice to all source files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 # Scratch for iOS
 
 This is a version of Scratch forked from scratch-gui that uses Capacitor to make it work on iOS.

--- a/capacitor.config.json
+++ b/capacitor.config.json
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 {
   "appId": "com.cameron.Scratch",
   "appName": "Scratch For IOS",

--- a/ios/.gitignore
+++ b/ios/.gitignore
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 App/build
 App/Pods
 App/output

--- a/ios/App/App.xcodeproj/project.pbxproj
+++ b/ios/App/App.xcodeproj/project.pbxproj
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 {
 	archiveVersion = 1;
 	classes = {

--- a/ios/App/App.xcworkspace/contents.xcworkspacedata
+++ b/ios/App/App.xcworkspace/contents.xcworkspacedata
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 <?xml version="1.0" encoding="UTF-8"?>
 <Workspace
    version = "1.0">

--- a/ios/App/App.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ios/App/App.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/ios/App/App/AppDelegate.swift
+++ b/ios/App/App/AppDelegate.swift
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 import UIKit
 import Capacitor
 

--- a/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 {
   "images" : [
     {

--- a/ios/App/App/Info.plist
+++ b/ios/App/App/Info.plist
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">

--- a/package.json
+++ b/package.json
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 {
   "name": "ios-scratch",
   "version": "1.0.0",

--- a/www/extension-worker.js
+++ b/www/extension-worker.js
@@ -1,3 +1,13 @@
+/*
+This project is licensed under the GNU Affero General Public License (AGPL).
+
+This program is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Affero General Public License for more details.
+
+You should have received a copy of the GNU Affero General Public License along with this program. If not, see <https://www.gnu.org/licenses/>.
+*/
+
 (function webpackUniversalModuleDefinition(root, factory) {
 	if(typeof exports === 'object' && typeof module === 'object')
 		module.exports = factory();


### PR DESCRIPTION
Add AGPL license notice to all source files.

* Add AGPL license notice at the top of `capacitor.config.json`.
* Add AGPL license notice at the top of `ios/.gitignore`.
* Add AGPL license notice at the top of `ios/App/App.xcodeproj/project.pbxproj`.
* Add AGPL license notice at the top of `ios/App/App.xcworkspace/contents.xcworkspacedata`.
* Add AGPL license notice at the top of `ios/App/App.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist`.
* Add AGPL license notice at the top of `ios/App/App/AppDelegate.swift`.
* Add AGPL license notice at the top of `ios/App/App/Assets.xcassets/AppIcon.appiconset/Contents.json`.
* Add AGPL license notice at the top of `ios/App/App/Info.plist`.
* Add AGPL license notice at the top of `package.json`.
* Add AGPL license notice at the top of `README.md`.
* Add AGPL license notice at the top of `www/extension-worker.js`.

